### PR TITLE
[KF 34] Feat: 검색 페이지 및 숙소 상세 페이지 찜 터치 시 찜 항목 추가 기능

### DIFF
--- a/src/main/webapp/css/jjim.css
+++ b/src/main/webapp/css/jjim.css
@@ -21,6 +21,14 @@
 	text-decoration: underline;
 }
 
+.none-data {
+  display: block;
+  text-align: center;
+  font-size: 30px;
+  color: #888;
+  margin: 40px 0;
+}
+
 .cards {
 	display: flex;
 	justify-content: center;
@@ -33,7 +41,7 @@
 	width: 559px;
 	background: #fff;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	overflow: hidden;
+	overflow: visible;
 	position: relative;
 	background: #fff;
 }
@@ -173,5 +181,73 @@
 .booking-container p {
 	width: 100%;
 	margin-top: 12px;
+	text-align: right;
+}
+
+.room-slider {
+	margin-top: 10px;
+}
+
+.room-slide {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	overflow: visible !important;
+	padding-bottom: 10px;
+	gap: 10px;
+	padding: 10px;
+	border: none;
+	border-radius: 8px;
+	background: #fdfdfd;
+}
+
+.slick-prev::before,
+.slick-next::before {
+    color: var(--primary-color) !important;
+}
+
+.slick-prev:hover,
+.slick-next:hover {
+    color: var(--secondary-color);
+    opacity: 1;
+}
+
+.slick-prev.slick-disabled,
+.slick-next.slick-disabled {
+    visibility: hidden;
+    pointer-events: none;
+    opacity: 0.2;
+}
+
+
+.room-info {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	gap: 10px;
+}
+
+.room-info img {
+	width: 80px;
+	height: 80px;
+	object-fit: cover;
+	border-radius: 6px;
+}
+
+.room-details {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	font-size: 14px;
+	flex: 1;
+}
+
+.price {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: flex-end;
+	min-width: 90px;
 	text-align: right;
 }

--- a/src/main/webapp/detailpage.html
+++ b/src/main/webapp/detailpage.html
@@ -52,8 +52,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /> <span class="room-limit">기준 2인 최대 2인</span></div>
+                                <div class="room-beds"><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 1개 </span></div>
                             </div>
                         </div>
 
@@ -81,8 +81,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /> <span class="room-limit">기준 2인 최대 2인</span></div>
+                                <div class="room-beds"><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 1개 </span></div>
                             </div>
                         </div>
 
@@ -114,8 +114,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /> <span class="room-limit">기준 4인 최대 4인 </span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 2개</span></div>
                             </div>
                         </div>
 
@@ -143,8 +143,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 4인 최대 4인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 4개</span></div>
                             </div>
                         </div>
 
@@ -175,8 +175,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 4인 최대 6인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 2개</span></div>
                             </div>
                         </div>
 
@@ -204,8 +204,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 4인 최대 6인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 2개</span></div>
                             </div>
                         </div>
 
@@ -236,8 +236,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 6인 최대 6인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 3개</span></div>
                             </div>
                         </div>
 
@@ -265,8 +265,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 6인 최대 6인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 3개</span></div>
                             </div>
                         </div>
 
@@ -297,8 +297,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 6인 최대 8인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 3개</span></div>
                             </div>
                         </div>
 
@@ -326,8 +326,8 @@
                             </div>
                             <div class="room-desc">보풀리스, 디즈니, 티빙</div>
                             <div class="room-meta">
-                                <div><img src="image/person.png" class="icon" /> 기준 2인 최대 2인</div>
-                                <div><img src="image/bed.png" class="icon" /> 침대 1개</div>
+                                <div><img src="image/person.png" class="icon" /><span class="room-limit">기준 6인 최대 8인</span></div>
+                                <div><img src="image/bed.png" class="icon" /><span class="room-bed"> 침대 3개</span></div>
                             </div>
                         </div>
 

--- a/src/main/webapp/jjim.html
+++ b/src/main/webapp/jjim.html
@@ -26,61 +26,7 @@
 
       <!-- 카드 리스트 -->
       <div class="cards">
-        <!-- 첫 번째 카드 -->
-        <div class="card">
-          <div class="main-image-wrapper">
-            <div class="checkbox">
-              <input type="checkbox" id="card1" />
-            </div>
-            <img src="./image/jjim-1.webp" alt="파티앤파티" class="main" />
-          </div>
-          <div class="card-content">
-            <div class="title">파티앤파티 홍대</div>
-            <div class="location">📍 친구와 함께한 1박 2일 (수정함)</div>
-            <div class="room-info">
-              <img src="./image/jjim-3.webp" alt="싱글룸 이미지" />
-              <div class="room-details">
-                <div class="room-top">싱글룸_1</div>
-                <div class="room-middle">넷플릭스, 디즈니, 티빙</div>
-                <div class="room-bottom">
-                  👥기준 2인/최대 2인 <br /> 🛏️퀸 침대 1개
-                </div>
-              </div>
-            </div>
-            <div class="price">
-              <del>45,000원</del>
-              <span>25,000원</span>
-            </div>
-          </div>
-        </div>
-
-        <!-- 두 번째 카드 -->
-        <div class="card">
-          <div class="main-image-wrapper">
-            <div class="checkbox">
-              <input type="checkbox" id="card2" />
-            </div>
-            <img src="./image/jjim-2.webp" alt="장기숙박형" class="main" />
-          </div>
-          <div class="card-content">
-            <div class="title">장기 숙박형</div>
-            <div class="location">📍 조용히 힐링하고 가요 (수정함)</div>
-            <div class="room-info">
-              <img src="./image/jjim-3.webp" alt="싱글룸 이미지" />
-              <div class="room-details">
-                <div class="room-top">싱글룸_2</div>
-                <div class="room-middle">공유라운지+셀프키친</div>
-                <div class="room-bottom">
-                  👥기준 2인/최대 2인 <br /> 🛏️퀸 침대 1개
-                </div>
-              </div>
-            </div>
-            <div class="price">
-              <del>85,000원</del>
-              <span>47,000원</span>
-            </div>
-          </div>
-        </div>
+        
       </div>
 
       <div class="booking-container">
@@ -165,11 +111,15 @@
     </div>
   </div>
 
-  <!-- js 라이브러리 -->
-  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 
-  <!-- js 파일 -->
-  <script src="js/common.js"></script>
-  <script src="js/jjim.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css" />
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css" />
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+
+<script src="js/common.js"></script>
+<script src="js/jjim.js"></script>
 </body>
 </html>

--- a/src/main/webapp/js/SearchPageJs.js
+++ b/src/main/webapp/js/SearchPageJs.js
@@ -10,6 +10,7 @@ $(function () {
         if (selectedCategory === "전체") {
             $('#search-list').css('display', 'none');
             $('#search-total').css('display', 'block');
+            restoreHeartButtons();
         } else {
             $('#search-total').css('display', 'none');
             $('#search-list').css('display', 'flex');
@@ -20,7 +21,6 @@ $(function () {
     // 초기 전체 뷰 표시
     $('#search-total').show();
     renderCards();
-
     // 정렬 토글
     const container = document.querySelector(".sort-container");
     const toggle = container.querySelector(".sort-toggle");
@@ -63,8 +63,29 @@ $(function () {
         e.stopPropagation();
         const heartImg = $(this).find('.heart-img');
         heartImg.toggleClass('heart-active');
-        const isActive = heartImg.hasClass('heart-active');
-        heartImg.attr('src', isActive ? "image/heart_sel.webp" : "image/heart_non.webp");
+        heartImg.attr('src', heartImg.hasClass('heart-active') ? "image/heart_sel.webp" : "image/heart_non.webp");
+
+        const card = $(this).closest('.card');
+        const title = card.find('.card-title').text().trim();
+        const image = card.find('.card-img').attr('src');
+        const location = card.find('.location-text').text().trim();
+
+        let jjimCards = JSON.parse(localStorage.getItem('jjimCards') || '[]');
+        const exists = jjimCards.some(item => item.title === title);
+
+        if (exists) {
+            // 찜 해제
+            jjimCards = jjimCards.filter(item => item.title !== title);
+            heartImg.removeClass('heart-active');
+            heartImg.attr('src', 'image/heart_non.webp');
+        } else {
+            // 찜 추가
+            jjimCards.push({ title, image, location});
+            heartImg.addClass('heart-active');
+            heartImg.attr('src', 'image/heart_sel.webp');
+        }
+
+        localStorage.setItem('jjimCards', JSON.stringify(jjimCards));
     });
 
     // 카드 클릭
@@ -78,4 +99,24 @@ $(function () {
         const url = `detailpage.html?title=${encodeURIComponent(title)}&image=${encodeURIComponent(image)}&location=${encodeURIComponent(location)}&originalPrice=${encodeURIComponent(originalPrice)}&discountPrice=${encodeURIComponent(discountPrice)}`;
         window.location.href = url;
     });
+
+
 });
+
+function restoreHeartButtons() {
+    const jjimCards = JSON.parse(localStorage.getItem('jjimCards') || '[]');
+
+    $('.card').each(function () {
+        const title = $(this).find('.card-title').text().trim();
+        const heartImg = $(this).find('.heart-img');
+
+        const isJjimmed = jjimCards.some(item => item.title === title);
+        if (isJjimmed) {
+            heartImg.addClass('heart-active');
+            heartImg.attr('src', 'image/heart_sel.webp');
+        } else {
+            heartImg.removeClass('heart-active');
+            heartImg.attr('src', 'image/heart_non.webp');
+        }
+    });
+}

--- a/src/main/webapp/js/cardRenderer.js
+++ b/src/main/webapp/js/cardRenderer.js
@@ -435,7 +435,7 @@ function renderCards() {
             slidesToScroll: 2,
             rows: 1,
         });
-
+        restoreHeartButtons();
         hideSpinner();
     }, 1000);
 }
@@ -474,6 +474,7 @@ function renderCardListViewByCategory(category) {
 
     // 정렬 후 첫 카드 로딩
     sortCardsByOption(currentSortOption);
+    restoreHeartButtons();
     renderNextCards();
 }
 
@@ -503,6 +504,7 @@ function renderNextCards() {
             // 모든 카드 로딩됨
             spinner.remove(); // spinner 완전히 제거
             listObserver.unobserve(spinner);
+
         } else {
             spinner.style.display = 'flex';
 
@@ -512,7 +514,9 @@ function renderNextCards() {
                 window._observerInitialized = true;
             }
         }
+
     }, 500);
+
 }
 
 function sortCardsByOption(optionText = "예약가 높은순") {


### PR DESCRIPTION
### 설명
검색 및 숙소 상세 페이지에서 찜하기 버튼 클릭 시, 해당 게스트하우스가 찜 페이지에 추가됩니다.

- 게스트하우스만 찜할 경우, "방 정보 없음" 메시지가 표시됩니다.

- 이후 방을 추가로 찜할 경우, 해당 게스트하우스가 이미 찜 목록에 존재하면 기존 항목에 방 정보가 누적됩니다.

- 방이 여러 개인 경우에는 Slick 슬라이더를 이용해 슬라이드 형태로 시각화됩니다.

---

### TODO
- [x] 찜 항목 데이터 추가 기능 구현
- [x] 검색 및 숙소 상세 페이지에서 찜하기 버튼 연결
- [x] 다중 방 데이터 슬라이드(Slick) 출력 처리

---

###ETC
- 예약 모달 기능이 완료되면, 해당 기능을 숙소 상세 페이지에도 연동할 예정입니다.